### PR TITLE
add 'Accept' header to podnapisi provider; fixes #60

### DIFF
--- a/Subliminal/subliminal/providers/podnapisi.py
+++ b/Subliminal/subliminal/providers/podnapisi.py
@@ -92,6 +92,7 @@ class PodnapisiProvider(Provider):
     def initialize(self):
         self.session = requests.Session()
         self.headers = {
+            'Accept': '*/*',
             'User-Agent': self.random_user_agent,
             'Referer': '%s/subtitles/search/advanced' % self.server
         }


### PR DESCRIPTION
Without the 'Accept' header, Podnapisi seems to always return a status code of
415 (Unsupported Media Type). Not sure why but setting it explicitly appears to
fix the issue.